### PR TITLE
Fix E2E subscription test hydration race

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,3 +1,0 @@
-## Problems
-
-- client.n-qD7hcj.js:24 Uncaught Error: Minified React error #418; visit https://react.dev/errors/418?args[]=text&args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.

--- a/packages/e2e/src/scenarios/web-critical-flows.spec.ts
+++ b/packages/e2e/src/scenarios/web-critical-flows.spec.ts
@@ -18,7 +18,7 @@ test.describe("GraphQL Weekly", () => {
   });
 
   test("newsletter subscription flow", async ({ page }) => {
-    await page.goto(WEB_URL);
+    await page.goto(WEB_URL, { waitUntil: "networkidle" });
 
     const nameInput = page.getByRole("textbox", { name: /name/i });
     const emailInput = page.getByRole("textbox", { name: /email/i });


### PR DESCRIPTION
## Summary
- Wait for `networkidle` before interacting with subscription form
- Ensures React hydrates before test clicks Submit

## Root cause
Test clicked Subscribe before React hydrated → `onSubmit` handler not attached → native form submission (no-op) → no success/error message appeared.