### PR TITLE
Fix submissions panel header blinking during drag

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@graphqlweekly/monorepo",
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260113.0",
+        "@cloudflare/workers-types": "^4.20260124.0",
         "@hasparus/eslint-config": "2.0.13",
         "@playwright/test": "^1.57.0",
         "eslint": "9.39.2",
@@ -324,7 +324,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260111.0", "", { "os": "win32", "cpu": "x64" }, "sha512-zWgd77L7OI1BxgBbG+2gybDahIMgPX5iNo6e3LqcEz1Xm3KfiqgnDyMBcxeQ7xDrj7fHUGAlc//QnKvDchuUoQ=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260113.0", "", {}, "sha512-CS2tUdGn1EMAV5GoFYYUfsZ4vwwXiYxwrUiI8ZRkxrJGqkHNGily/5Zf+vt/wh1HSoiCIChNYiuLEoCA/XUybw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260124.0", "", {}, "sha512-h6TJlew6AtGuEXFc+k5ifalk+tg3fkg0lla6XbMAb2AKKfJGwlFNTwW2xyT/Ha92KY631CIJ+Ace08DPdFohdA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -3075,8 +3075,6 @@
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "@floating-ui/react-dom/@floating-ui/dom": ["@floating-ui/dom@1.7.5", "", { "dependencies": { "@floating-ui/core": "^1.7.4", "@floating-ui/utils": "^0.2.10" } }, "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg=="],
-
-    "@gqlweekly/api/@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260124.0", "", {}, "sha512-h6TJlew6AtGuEXFc+k5ifalk+tg3fkg0lla6XbMAb2AKKfJGwlFNTwW2xyT/Ha92KY631CIJ+Ace08DPdFohdA=="],
 
     "@gqlweekly/cms/graphql": ["graphql@16.12.0", "", {}, "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/react": "19.2.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20260113.0",
+    "@cloudflare/workers-types": "^4.20260124.0",
     "@hasparus/eslint-config": "2.0.13",
     "@playwright/test": "^1.57.0",
     "eslint": "9.39.2",

--- a/packages/cms/src/islands/issue.tsx
+++ b/packages/cms/src/islands/issue.tsx
@@ -58,7 +58,6 @@ import { PageHeader } from "../product/PageHeader";
 import {
   markSubmissionConsumed,
   SUBMISSION_PREFIX,
-  SUBMISSIONS_PANEL_ID,
   SubmissionsPanel,
 } from "../product/SubmissionsPanel";
 import { TopicAutocomplete } from "../product/TopicAutocomplete";
@@ -663,7 +662,6 @@ function IssuePageContent({ id }: { id: string }) {
             measuring={{ droppable: { strategy: MeasuringStrategy.Always } }}
             onDragCancel={onDragCancel}
             onDragEnd={({ active, over }) => {
-              if (active.id === SUBMISSIONS_PANEL_ID) return;
               const activeIdStr = String(active.id);
               const isSubmission = activeIdStr.startsWith(SUBMISSION_PREFIX);
 
@@ -821,7 +819,6 @@ function IssuePageContent({ id }: { id: string }) {
               setActiveSubmission(null);
             }}
             onDragOver={({ active, over }) => {
-              if (active.id === SUBMISSIONS_PANEL_ID) return;
               const overId = over?.id;
               if (overId == null || overId === TRASH_ID || active.id in items)
                 return;
@@ -878,7 +875,6 @@ function IssuePageContent({ id }: { id: string }) {
               });
             }}
             onDragStart={({ active }) => {
-              if (active.id === SUBMISSIONS_PANEL_ID) return;
               setActiveId(active.id);
               setClonedItems(items);
 


### PR DESCRIPTION
## Summary
- Replace dnd-kit `useDraggable`/`useDndMonitor` with `@use-gesture/react` for panel repositioning — panel drag no longer triggers dnd-kit context updates or full-tree re-renders
- Add 48px top constraint so panel can't overlap the navbar
- Remove dead `SUBMISSIONS_PANEL_ID` guards from issue.tsx
- Align `@cloudflare/workers-types` version across workspace

## Test plan
- [x] Drag the submissions panel left to right — header should not blink
- [x] Drag panel to top of viewport — should stop below the navbar
- [x] Drag submissions from panel into topic containers — still works