### PR TITLE
Fix link ordering in issue page

### DIFF
--- a/packages/web/src/components/home/Content/Issue.tsx
+++ b/packages/web/src/components/home/Content/Issue.tsx
@@ -55,7 +55,7 @@ export const Issue = ({ firstIssueNumber, issue, lastIssueNumber }: Props) => {
         return (
           <TopicBox
             articles={topic.links
-              .sort((a, b) => b.position - a.position)
+              .sort((a, b) => a.position - b.position)
               .map((link) => (
                 <TopicArticle
                   key={link.title}


### PR DESCRIPTION
## Summary
- Sort links ascending by position (`a - b`) instead of descending (`b - a`) in `Issue.tsx`
- This caused issue 404's Community section to display links in reverse drag-and-drop order

## Test plan
- [x] Verify issue 404 shows links in correct order after deploy