### PR TITLE
Fix publish workflow permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Add `permissions: contents: write` to publish job so github-actions[bot] can push the empty commit
- Without this, the push fails with 403: `Permission to graphql-hive/graphql-weekly.git denied to github-actions[bot]`

## Bonus
Merging this PR triggers CI deploy → rebuilds web (unblocks issue 405 publish).

## Remaining issue
The `repository_dispatch` trigger from the API worker returns 403 with the fine-grained PAT. Need to replace `GITHUB_TOKEN` with a classic PAT (`repo` scope) on the worker:
```sh
wrangler secret put GITHUB_TOKEN
```